### PR TITLE
Click listener View param nullability fix

### DIFF
--- a/app/src/main/java/co/zsmb/materialdrawerktexample/DrawerActivity.kt
+++ b/app/src/main/java/co/zsmb/materialdrawerktexample/DrawerActivity.kt
@@ -281,7 +281,7 @@ class DrawerActivity : AppCompatActivity() {
         }
     }
 
-    private fun <T : Activity> openActivity(activity: KClass<T>): (View) -> Boolean = {
+    private fun <T : Activity> openActivity(activity: KClass<T>): (View?) -> Boolean = {
         startActivity(Intent(this@DrawerActivity, activity.java))
         false
     }

--- a/library/src/main/java/co/zsmb/materialdrawerkt/builders/DrawerBuilderKt.kt
+++ b/library/src/main/java/co/zsmb/materialdrawerkt/builders/DrawerBuilderKt.kt
@@ -740,7 +740,7 @@ class DrawerBuilderKt(val activity: Activity) : Builder {
      * @param position The position of the clicked item within the drawer
      * @param drawerItem The clicked drawer item
      */
-    fun onItemClick(handler: (view: View, position: Int, drawerItem: IDrawerItem<*, *>) -> Boolean) {
+    fun onItemClick(handler: (view: View?, position: Int, drawerItem: IDrawerItem<*, *>) -> Boolean) {
         builder.withOnDrawerItemClickListener(handler)
     }
 

--- a/library/src/main/java/co/zsmb/materialdrawerkt/draweritems/base/AbstractDrawerItemKt.kt
+++ b/library/src/main/java/co/zsmb/materialdrawerkt/draweritems/base/AbstractDrawerItemKt.kt
@@ -79,7 +79,7 @@ abstract class AbstractDrawerItemKt : Builder {
      *
      * Wraps the [AbstractDrawerItem.withOnDrawerItemClickListener] method.
      */
-    fun onClick(handler: (view: View) -> Boolean) {
+    fun onClick(handler: (view: View?) -> Boolean) {
         item.withOnDrawerItemClickListener { view, _, _ -> handler(view) }
     }
 
@@ -94,7 +94,7 @@ abstract class AbstractDrawerItemKt : Builder {
      * @param position The position of the item within the drawer
      * @param drawerItem The drawer item itself
      */
-    fun onClick(handler: (view: View, position: Int, drawerItem: IDrawerItem<*, *>) -> Boolean) {
+    fun onClick(handler: (view: View?, position: Int, drawerItem: IDrawerItem<*, *>) -> Boolean) {
         item.withOnDrawerItemClickListener(handler)
     }
 


### PR DESCRIPTION
Fixes #59, a bug where the incoming `View` in click listeners was assumed to be non-null by the Kotlin library, causing a crash when the base library sometimes passed a `null` value as the `View` parameter. 