### PR TITLE
Support for Androidx

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -6,7 +6,7 @@ apply from: '../testformatter.gradle'
 
 android {
     compileSdkVersion 28
-    buildToolsVersion '28.0.0'
+    buildToolsVersion '28.0.2'
     defaultConfig {
         applicationId "co.zsmb.materialdrawerktexample"
         minSdkVersion 14

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -30,10 +30,10 @@ android {
 dependencies {
     implementation project(path: ':library')
 
-    implementation "com.android.support:appcompat-v7:$support_lib_version"
-    implementation "com.android.support:recyclerview-v7:$support_lib_version"
-    implementation "com.android.support:support-annotations:$support_lib_version"
-    implementation "com.android.support:design:$support_lib_version"
+    implementation 'androidx.appcompat:appcompat:1.0.0-rc02'
+    implementation 'androidx.recyclerview:recyclerview:1.0.0-rc02'
+    implementation 'androidx.annotation:annotation:1.0.0-rc02'
+    implementation 'com.google.android.material:material:1.0.0-rc02'
 
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
 

--- a/app/src/main/java/co/zsmb/materialdrawerktexample/DrawerActivity.kt
+++ b/app/src/main/java/co/zsmb/materialdrawerktexample/DrawerActivity.kt
@@ -4,7 +4,7 @@ import android.app.Activity
 import android.content.Intent
 import android.graphics.Color
 import android.os.Bundle
-import android.support.v7.app.AppCompatActivity
+import androidx.appcompat.app.AppCompatActivity
 import android.view.View
 import co.zsmb.materialdrawerkt.builders.accountHeader
 import co.zsmb.materialdrawerkt.builders.drawer

--- a/app/src/main/java/co/zsmb/materialdrawerktexample/customitems/customurl/CustomBaseViewHolder.java
+++ b/app/src/main/java/co/zsmb/materialdrawerktexample/customitems/customurl/CustomBaseViewHolder.java
@@ -1,6 +1,6 @@
 package co.zsmb.materialdrawerktexample.customitems.customurl;
 
-import android.support.v7.widget.RecyclerView;
+import androidx.recyclerview.widget.RecyclerView;
 import android.view.View;
 import android.widget.ImageView;
 import android.widget.TextView;

--- a/app/src/main/java/co/zsmb/materialdrawerktexample/customitems/customurl/CustomUrlBasePrimaryDrawerItem.java
+++ b/app/src/main/java/co/zsmb/materialdrawerktexample/customitems/customurl/CustomUrlBasePrimaryDrawerItem.java
@@ -2,10 +2,10 @@ package co.zsmb.materialdrawerktexample.customitems.customurl;
 
 import android.content.Context;
 import android.net.Uri;
-import android.support.annotation.ColorInt;
-import android.support.annotation.ColorRes;
-import android.support.annotation.StringRes;
-import android.support.v7.widget.RecyclerView;
+import androidx.annotation.ColorInt;
+import androidx.annotation.ColorRes;
+import androidx.annotation.StringRes;
+import androidx.recyclerview.widget.RecyclerView;
 import com.mikepenz.materialdrawer.holder.ColorHolder;
 import com.mikepenz.materialdrawer.holder.ImageHolder;
 import com.mikepenz.materialdrawer.holder.StringHolder;

--- a/app/src/main/java/co/zsmb/materialdrawerktexample/customitems/customurl/CustomUrlPrimaryDrawerItem.java
+++ b/app/src/main/java/co/zsmb/materialdrawerktexample/customitems/customurl/CustomUrlPrimaryDrawerItem.java
@@ -1,8 +1,8 @@
 package co.zsmb.materialdrawerktexample.customitems.customurl;
 
 import android.content.Context;
-import android.support.annotation.LayoutRes;
-import android.support.annotation.StringRes;
+import androidx.annotation.LayoutRes;
+import androidx.annotation.StringRes;
 import android.view.View;
 import android.widget.TextView;
 import co.zsmb.materialdrawerktexample.R;

--- a/app/src/main/java/co/zsmb/materialdrawerktexample/customitems/overflow/OverflowMenuDrawerItem.kt
+++ b/app/src/main/java/co/zsmb/materialdrawerktexample/customitems/overflow/OverflowMenuDrawerItem.kt
@@ -1,7 +1,7 @@
 package co.zsmb.materialdrawerktexample.customitems.overflow
 
-import android.support.annotation.LayoutRes
-import android.support.v7.widget.PopupMenu
+import androidx.annotation.LayoutRes
+import androidx.appcompat.widget.PopupMenu
 import android.view.View
 import android.widget.ImageButton
 import co.zsmb.materialdrawerktexample.R

--- a/app/src/main/java/co/zsmb/materialdrawerktexample/customitems/overflow/OverflowMenuDrawerItemKt.kt
+++ b/app/src/main/java/co/zsmb/materialdrawerktexample/customitems/overflow/OverflowMenuDrawerItemKt.kt
@@ -1,6 +1,6 @@
 package co.zsmb.materialdrawerktexample.customitems.overflow
 
-import android.support.v7.widget.PopupMenu
+import androidx.appcompat.widget.PopupMenu
 import android.view.MenuItem
 import co.zsmb.materialdrawerkt.builders.Builder
 import co.zsmb.materialdrawerkt.createItem

--- a/app/src/main/java/co/zsmb/materialdrawerktexample/fragments/DrawerFragment.kt
+++ b/app/src/main/java/co/zsmb/materialdrawerktexample/fragments/DrawerFragment.kt
@@ -1,7 +1,7 @@
 package co.zsmb.materialdrawerktexample.fragments
 
 import android.os.Bundle
-import android.support.v4.app.Fragment
+import androidx.fragment.app.Fragment
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -14,7 +14,7 @@ import com.mikepenz.fontawesome_typeface_library.FontAwesome
 import com.mikepenz.materialdrawer.Drawer
 import kotlinx.android.synthetic.main.fragment_simple_sample.view.*
 
-class DrawerFragment : Fragment() {
+class DrawerFragment : androidx.fragment.app.Fragment() {
 
     private lateinit var result: Drawer
 

--- a/app/src/main/java/co/zsmb/materialdrawerktexample/fragments/SecondDrawerFragment.kt
+++ b/app/src/main/java/co/zsmb/materialdrawerktexample/fragments/SecondDrawerFragment.kt
@@ -1,7 +1,7 @@
 package co.zsmb.materialdrawerktexample.fragments
 
 import android.os.Bundle
-import android.support.v4.app.Fragment
+import androidx.fragment.app.Fragment
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -12,7 +12,7 @@ import com.mikepenz.fontawesome_typeface_library.FontAwesome
 import com.mikepenz.materialdrawer.Drawer
 import kotlinx.android.synthetic.main.fragment_simple_sample.view.*
 
-class SecondDrawerFragment : Fragment() {
+class SecondDrawerFragment : androidx.fragment.app.Fragment() {
 
     private lateinit var result: Drawer
 

--- a/app/src/main/java/co/zsmb/materialdrawerktexample/newactivities/AccountHeaderActivity.kt
+++ b/app/src/main/java/co/zsmb/materialdrawerktexample/newactivities/AccountHeaderActivity.kt
@@ -1,7 +1,7 @@
 package co.zsmb.materialdrawerktexample.newactivities
 
 import android.os.Bundle
-import android.support.v7.app.AppCompatActivity
+import androidx.appcompat.app.AppCompatActivity
 import android.view.MenuItem
 import co.zsmb.materialdrawerkt.builders.accountHeader
 import co.zsmb.materialdrawerkt.builders.drawer

--- a/app/src/main/java/co/zsmb/materialdrawerktexample/newactivities/BadgesActivity.kt
+++ b/app/src/main/java/co/zsmb/materialdrawerktexample/newactivities/BadgesActivity.kt
@@ -1,7 +1,7 @@
 package co.zsmb.materialdrawerktexample.newactivities
 
 import android.os.Bundle
-import android.support.v7.app.AppCompatActivity
+import androidx.appcompat.app.AppCompatActivity
 import android.view.MenuItem
 import co.zsmb.materialdrawerkt.builders.accountHeader
 import co.zsmb.materialdrawerkt.builders.drawer

--- a/app/src/main/java/co/zsmb/materialdrawerktexample/newactivities/DrawerItemTypesActivity.kt
+++ b/app/src/main/java/co/zsmb/materialdrawerktexample/newactivities/DrawerItemTypesActivity.kt
@@ -1,7 +1,7 @@
 package co.zsmb.materialdrawerktexample.newactivities
 
 import android.os.Bundle
-import android.support.v7.app.AppCompatActivity
+import androidx.appcompat.app.AppCompatActivity
 import android.view.MenuItem
 import co.zsmb.materialdrawerkt.builders.accountHeader
 import co.zsmb.materialdrawerkt.builders.drawer

--- a/app/src/main/java/co/zsmb/materialdrawerktexample/newactivities/HeaderFooterActivity.kt
+++ b/app/src/main/java/co/zsmb/materialdrawerktexample/newactivities/HeaderFooterActivity.kt
@@ -1,7 +1,7 @@
 package co.zsmb.materialdrawerktexample.newactivities
 
 import android.os.Bundle
-import android.support.v7.app.AppCompatActivity
+import androidx.appcompat.app.AppCompatActivity
 import android.view.MenuItem
 import co.zsmb.materialdrawerkt.builders.drawer
 import co.zsmb.materialdrawerkt.builders.footer

--- a/app/src/main/java/co/zsmb/materialdrawerktexample/newactivities/ListenersActivity.kt
+++ b/app/src/main/java/co/zsmb/materialdrawerktexample/newactivities/ListenersActivity.kt
@@ -1,7 +1,7 @@
 package co.zsmb.materialdrawerktexample.newactivities
 
 import android.os.Bundle
-import android.support.v7.app.AppCompatActivity
+import androidx.appcompat.app.AppCompatActivity
 import android.util.Log
 import android.view.MenuItem
 import co.zsmb.materialdrawerkt.builders.drawer

--- a/app/src/main/java/co/zsmb/materialdrawerktexample/originalactivities/ActionBarActivity.kt
+++ b/app/src/main/java/co/zsmb/materialdrawerktexample/originalactivities/ActionBarActivity.kt
@@ -1,7 +1,7 @@
 package co.zsmb.materialdrawerktexample.originalactivities
 
 import android.os.Bundle
-import android.support.v7.app.AppCompatActivity
+import androidx.appcompat.app.AppCompatActivity
 import android.view.MenuItem
 import co.zsmb.materialdrawerkt.R.layout.material_drawer_fits_not
 import co.zsmb.materialdrawerkt.builders.drawer

--- a/app/src/main/java/co/zsmb/materialdrawerktexample/originalactivities/AdvancedDrawerActivity.kt
+++ b/app/src/main/java/co/zsmb/materialdrawerktexample/originalactivities/AdvancedDrawerActivity.kt
@@ -1,7 +1,7 @@
 package co.zsmb.materialdrawerktexample.originalactivities
 
 import android.os.Bundle
-import android.support.v7.app.AppCompatActivity
+import androidx.appcompat.app.AppCompatActivity
 import android.view.Menu
 import android.view.MenuItem
 import co.zsmb.materialdrawerkt.builders.accountHeader

--- a/app/src/main/java/co/zsmb/materialdrawerktexample/originalactivities/CompactHeaderDrawerActivity.kt
+++ b/app/src/main/java/co/zsmb/materialdrawerktexample/originalactivities/CompactHeaderDrawerActivity.kt
@@ -1,7 +1,7 @@
 package co.zsmb.materialdrawerktexample.originalactivities
 
 import android.os.Bundle
-import android.support.v7.app.AppCompatActivity
+import androidx.appcompat.app.AppCompatActivity
 import android.view.MenuItem
 import co.zsmb.materialdrawerkt.builders.accountHeader
 import co.zsmb.materialdrawerkt.builders.drawer

--- a/app/src/main/java/co/zsmb/materialdrawerktexample/originalactivities/CustomContainerActivity.kt
+++ b/app/src/main/java/co/zsmb/materialdrawerktexample/originalactivities/CustomContainerActivity.kt
@@ -1,7 +1,7 @@
 package co.zsmb.materialdrawerktexample.originalactivities
 
 import android.os.Bundle
-import android.support.v7.app.AppCompatActivity
+import androidx.appcompat.app.AppCompatActivity
 import co.zsmb.materialdrawerkt.builders.drawer
 import co.zsmb.materialdrawerkt.draweritems.badgeable.primaryItem
 import co.zsmb.materialdrawerkt.draweritems.badgeable.secondaryItem

--- a/app/src/main/java/co/zsmb/materialdrawerktexample/originalactivities/EmbeddedDrawerActivity.kt
+++ b/app/src/main/java/co/zsmb/materialdrawerktexample/originalactivities/EmbeddedDrawerActivity.kt
@@ -1,7 +1,7 @@
 package co.zsmb.materialdrawerktexample.originalactivities
 
 import android.os.Bundle
-import android.support.v7.app.AppCompatActivity
+import androidx.appcompat.app.AppCompatActivity
 import android.view.MenuItem
 import co.zsmb.materialdrawerkt.builders.accountHeader
 import co.zsmb.materialdrawerkt.builders.drawer

--- a/app/src/main/java/co/zsmb/materialdrawerktexample/originalactivities/FragmentDrawerActivity.kt
+++ b/app/src/main/java/co/zsmb/materialdrawerktexample/originalactivities/FragmentDrawerActivity.kt
@@ -1,7 +1,7 @@
 package co.zsmb.materialdrawerktexample.originalactivities
 
 import android.os.Bundle
-import android.support.v7.app.AppCompatActivity
+import androidx.appcompat.app.AppCompatActivity
 import android.view.Menu
 import android.view.MenuItem
 import co.zsmb.materialdrawerktexample.R

--- a/app/src/main/java/co/zsmb/materialdrawerktexample/originalactivities/FullscreenDrawerActivity.kt
+++ b/app/src/main/java/co/zsmb/materialdrawerktexample/originalactivities/FullscreenDrawerActivity.kt
@@ -1,7 +1,7 @@
 package co.zsmb.materialdrawerktexample.originalactivities
 
 import android.os.Bundle
-import android.support.v7.app.AppCompatActivity
+import androidx.appcompat.app.AppCompatActivity
 import android.view.MenuItem
 import co.zsmb.materialdrawerkt.builders.drawer
 import co.zsmb.materialdrawerkt.draweritems.badgeable.primaryItem

--- a/app/src/main/java/co/zsmb/materialdrawerktexample/originalactivities/MenuDrawerActivity.kt
+++ b/app/src/main/java/co/zsmb/materialdrawerktexample/originalactivities/MenuDrawerActivity.kt
@@ -1,7 +1,7 @@
 package co.zsmb.materialdrawerktexample.originalactivities
 
 import android.os.Bundle
-import android.support.v7.app.AppCompatActivity
+import androidx.appcompat.app.AppCompatActivity
 import co.zsmb.materialdrawerkt.builders.drawer
 import co.zsmb.materialdrawerktexample.R
 import co.zsmb.materialdrawerktexample.utils.toast

--- a/app/src/main/java/co/zsmb/materialdrawerktexample/originalactivities/MiniDrawerActivity.kt
+++ b/app/src/main/java/co/zsmb/materialdrawerktexample/originalactivities/MiniDrawerActivity.kt
@@ -1,7 +1,7 @@
 package co.zsmb.materialdrawerktexample.originalactivities
 
 import android.os.Bundle
-import android.support.v7.app.AppCompatActivity
+import androidx.appcompat.app.AppCompatActivity
 import android.view.MenuItem
 import co.zsmb.materialdrawerkt.builders.accountHeader
 import co.zsmb.materialdrawerkt.builders.drawer

--- a/app/src/main/java/co/zsmb/materialdrawerktexample/originalactivities/MultiDrawerActivity.kt
+++ b/app/src/main/java/co/zsmb/materialdrawerktexample/originalactivities/MultiDrawerActivity.kt
@@ -1,7 +1,7 @@
 package co.zsmb.materialdrawerktexample.originalactivities
 
 import android.os.Bundle
-import android.support.v7.app.AppCompatActivity
+import androidx.appcompat.app.AppCompatActivity
 import android.view.Gravity
 import android.view.MenuItem
 import co.zsmb.materialdrawerkt.builders.drawer

--- a/app/src/main/java/co/zsmb/materialdrawerktexample/originalactivities/NonTranslucentDrawerActivity.kt
+++ b/app/src/main/java/co/zsmb/materialdrawerktexample/originalactivities/NonTranslucentDrawerActivity.kt
@@ -1,7 +1,7 @@
 package co.zsmb.materialdrawerktexample.originalactivities
 
 import android.os.Bundle
-import android.support.v7.app.AppCompatActivity
+import androidx.appcompat.app.AppCompatActivity
 import android.view.MenuItem
 import co.zsmb.materialdrawerkt.builders.drawer
 import co.zsmb.materialdrawerkt.draweritems.badgeable.primaryItem

--- a/app/src/main/res/layout/activity_embedded.xml
+++ b/app/src/main/res/layout/activity_embedded.xml
@@ -5,7 +5,7 @@
     android:gravity="center"
     android:orientation="vertical">
 
-    <android.support.v7.widget.Toolbar
+    <androidx.appcompat.widget.Toolbar
         android:id="@+id/toolbar"
         android:layout_width="match_parent"
         android:layout_height="?attr/actionBarSize"

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -5,7 +5,7 @@
     android:layout_height="match_parent"
     android:orientation="vertical">
 
-    <android.support.v7.widget.Toolbar
+    <androidx.appcompat.widget.Toolbar
         android:id="@+id/toolbar"
         android:layout_width="match_parent"
         android:layout_height="?attr/actionBarSize"

--- a/app/src/main/res/layout/activity_mini_drawer.xml
+++ b/app/src/main/res/layout/activity_mini_drawer.xml
@@ -6,7 +6,7 @@
     android:gravity="center"
     android:orientation="vertical">
 
-    <android.support.v7.widget.Toolbar
+    <androidx.appcompat.widget.Toolbar
         android:id="@+id/toolbar"
         android:layout_width="match_parent"
         android:layout_height="?attr/actionBarSize"

--- a/app/src/main/res/layout/activity_sample.xml
+++ b/app/src/main/res/layout/activity_sample.xml
@@ -6,7 +6,7 @@
     android:gravity="center"
     android:orientation="vertical">
 
-    <android.support.v7.widget.Toolbar
+    <androidx.appcompat.widget.Toolbar
         android:id="@+id/toolbar"
         android:layout_width="match_parent"
         android:layout_height="?attr/actionBarSize"

--- a/app/src/main/res/layout/activity_sample_custom_container_dark_toolbar.xml
+++ b/app/src/main/res/layout/activity_sample_custom_container_dark_toolbar.xml
@@ -6,7 +6,7 @@
     android:fitsSystemWindows="true"
     android:gravity="center">
 
-    <android.support.v7.widget.Toolbar
+    <androidx.appcompat.widget.Toolbar
         android:id="@+id/toolbar"
         android:layout_width="match_parent"
         android:layout_height="?attr/actionBarSize"

--- a/app/src/main/res/layout/activity_sample_dark_toolbar.xml
+++ b/app/src/main/res/layout/activity_sample_dark_toolbar.xml
@@ -6,7 +6,7 @@
     android:gravity="center"
     android:orientation="vertical">
 
-    <android.support.v7.widget.Toolbar
+    <androidx.appcompat.widget.Toolbar
         android:id="@+id/toolbar"
         android:layout_width="match_parent"
         android:layout_height="?attr/actionBarSize"

--- a/app/src/main/res/layout/activity_sample_fragment_dark_toolbar.xml
+++ b/app/src/main/res/layout/activity_sample_fragment_dark_toolbar.xml
@@ -7,7 +7,7 @@
     android:gravity="center"
     android:orientation="vertical">
 
-    <android.support.v7.widget.Toolbar
+    <androidx.appcompat.widget.Toolbar
         android:id="@+id/toolbar"
         android:layout_width="match_parent"
         android:layout_height="?attr/actionBarSize"

--- a/app/src/main/res/layout/activity_sample_fullscreen_dark_toolbar.xml
+++ b/app/src/main/res/layout/activity_sample_fullscreen_dark_toolbar.xml
@@ -21,7 +21,7 @@
 
     </FrameLayout>
 
-    <android.support.v7.widget.Toolbar
+    <androidx.appcompat.widget.Toolbar
         android:id="@+id/toolbar"
         android:layout_width="match_parent"
         android:layout_height="?attr/actionBarSize"

--- a/app/src/main/res/layout/activity_sample_logging.xml
+++ b/app/src/main/res/layout/activity_sample_logging.xml
@@ -5,7 +5,7 @@
     android:layout_height="match_parent"
     android:orientation="vertical">
 
-    <android.support.v7.widget.Toolbar
+    <androidx.appcompat.widget.Toolbar
         android:id="@+id/toolbar"
         android:layout_width="match_parent"
         android:layout_height="?attr/actionBarSize"

--- a/build.gradle
+++ b/build.gradle
@@ -1,12 +1,12 @@
 buildscript {
-    ext.kotlin_version = '1.2.51'
-    ext.support_lib_version = '27.1.1'
+    ext.kotlin_version = '1.2.61'
+    ext.support_lib_version = '28.0.0-rc02'
     repositories {
         jcenter()
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.1.3'
+        classpath 'com.android.tools.build:gradle:3.3.0-alpha08'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
 
         classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.4'

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
     ext.kotlin_version = '1.2.61'
-    ext.support_lib_version = '28.0.0-rc02'
+    ext.androidx_lib_version = '1.0.0-rc02'
     repositories {
         jcenter()
         google()

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,3 +7,5 @@ org.gradle.configureondemand=true
 
 org.gradle.daemon=true
 android.enableBuildCache=true
+android.useAndroidX=true
+android.enableJetifier=true

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.5.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.9-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -27,13 +27,13 @@ android {
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
 
-    api('com.mikepenz:materialdrawer:6.0.9@aar') {
+    api('com.mikepenz:materialdrawer:6.1.0-rc01') {
         transitive = true
     }
-    implementation "com.android.support:appcompat-v7:$support_lib_version"
-    implementation "com.android.support:recyclerview-v7:$support_lib_version"
-    implementation "com.android.support:support-annotations:$support_lib_version"
-    implementation "com.android.support:design:$support_lib_version"
+    implementation "androidx.appcompat:appcompat:$androidx_lib_version"
+    implementation "androidx.recyclerview:recyclerview:$androidx_lib_version"
+    implementation "androidx.annotation:annotation:$androidx_lib_version"
+    implementation "com.google.android.material:material:$androidx_lib_version"
 }
 
 apply from: '../testformatter.gradle'

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -8,7 +8,7 @@ apply plugin: "com.jfrog.bintray"
 ext {
     PUBLISH_GROUP_ID = 'co.zsmb'
     PUBLISH_ARTIFACT_ID = 'materialdrawer-kt'
-    PUBLISH_VERSION = '1.3.6'
+    PUBLISH_VERSION = '2.0.0'
 }
 
 android {

--- a/library/src/main/java/co/zsmb/materialdrawerkt/builders/Builder.kt
+++ b/library/src/main/java/co/zsmb/materialdrawerkt/builders/Builder.kt
@@ -11,6 +11,8 @@ interface Builder {
     /**
      * Attaches a drawer item (add as child or add to list, as applicable).
      */
+    @Deprecated(level = DeprecationLevel.WARNING,
+            message = "Only for use with custom drawer items.")
     fun attachItem(item: IDrawerItem<*, *>)
 
 }

--- a/library/src/main/java/co/zsmb/materialdrawerkt/builders/DrawerBuilderKt.kt
+++ b/library/src/main/java/co/zsmb/materialdrawerkt/builders/DrawerBuilderKt.kt
@@ -90,8 +90,7 @@ public class DrawerBuilderKt(val activity: Activity) : Builder {
     public fun drawer(param: () -> Unit = {}) {
     }
 
-    @Deprecated(level = DeprecationLevel.WARNING,
-            message = "Only for use with custom drawer items.")
+    @Suppress("OverridingDeprecatedMember")
     public override fun attachItem(item: IDrawerItem<*, *>) {
         builder.addDrawerItems(item)
     }

--- a/library/src/main/java/co/zsmb/materialdrawerkt/builders/DrawerBuilderKt.kt
+++ b/library/src/main/java/co/zsmb/materialdrawerkt/builders/DrawerBuilderKt.kt
@@ -6,11 +6,11 @@ import android.app.Activity
 import android.content.SharedPreferences
 import android.graphics.drawable.Drawable
 import android.os.Bundle
-import android.support.v4.app.Fragment
-import android.support.v4.widget.DrawerLayout
-import android.support.v7.app.ActionBarDrawerToggle
-import android.support.v7.widget.RecyclerView
-import android.support.v7.widget.Toolbar
+import androidx.fragment.app.Fragment
+import androidx.drawerlayout.widget.DrawerLayout
+import androidx.appcompat.app.ActionBarDrawerToggle
+import androidx.recyclerview.widget.RecyclerView
+import androidx.appcompat.widget.Toolbar
 import android.view.View
 import android.view.ViewGroup
 import co.zsmb.materialdrawerkt.DrawerMarker
@@ -38,7 +38,7 @@ public fun Activity.drawer(setup: DrawerBuilderKt.() -> Unit = {}): Drawer {
  *
  * @return The created Drawer instance
  */
-public fun Fragment.drawer(setup: DrawerBuilderKt.() -> Unit = {}): Drawer {
+public fun androidx.fragment.app.Fragment.drawer(setup: DrawerBuilderKt.() -> Unit = {}): Drawer {
     val fragmentActivity = activity ?: throw IllegalStateException("Fragment is not attached to an Activity")
     val builder = DrawerBuilderKt(fragmentActivity)
     builder.setup()
@@ -229,7 +229,7 @@ public class DrawerBuilderKt(val activity: Activity) : Builder {
      *
      * Non readable property. Wraps the [DrawerBuilder.withAdapter] method.
      */
-    public var adapter: FastAdapter<IDrawerItem<out Any?, out RecyclerView.ViewHolder>>
+    public var adapter: FastAdapter<IDrawerItem<out Any?, out androidx.recyclerview.widget.RecyclerView.ViewHolder>>
         @Deprecated(level = DeprecationLevel.ERROR, message = "Non readable property.")
         get() = nonReadable()
         set(value) {
@@ -242,7 +242,7 @@ public class DrawerBuilderKt(val activity: Activity) : Builder {
      *
      * Non readable property. Wraps the [DrawerBuilder.withAdapterWrapper] method.
      */
-    public var adapterWrapper: RecyclerView.Adapter<out RecyclerView.ViewHolder>
+    public var adapterWrapper: androidx.recyclerview.widget.RecyclerView.Adapter<out androidx.recyclerview.widget.RecyclerView.ViewHolder>
         @Deprecated(level = DeprecationLevel.ERROR, message = "Non readable property.")
         get() = nonReadable()
         set(value) {
@@ -355,7 +355,7 @@ public class DrawerBuilderKt(val activity: Activity) : Builder {
      *
      * Non readable property. Wraps the [DrawerBuilder.withDrawerLayout] method.
      */
-    public var drawerLayout: DrawerLayout
+    public var drawerLayout: androidx.drawerlayout.widget.DrawerLayout
         @Deprecated(level = DeprecationLevel.ERROR, message = "Non readable property.")
         get() = nonReadable()
         set(value) {
@@ -662,7 +662,7 @@ public class DrawerBuilderKt(val activity: Activity) : Builder {
      *
      * Non readable property. Wraps the [DrawerBuilder.withItemAnimator] method.
      */
-    public var itemAnimator: RecyclerView.ItemAnimator
+    public var itemAnimator: androidx.recyclerview.widget.RecyclerView.ItemAnimator
         @Deprecated(level = DeprecationLevel.ERROR, message = "Non readable property.")
         get() = nonReadable()
         set(value) {
@@ -842,7 +842,7 @@ public class DrawerBuilderKt(val activity: Activity) : Builder {
      *
      * Non readable property. Wraps the [DrawerBuilder.withRecyclerView] method.
      */
-    public var recyclerView: RecyclerView
+    public var recyclerView: androidx.recyclerview.widget.RecyclerView
         @Deprecated(level = DeprecationLevel.ERROR, message = "Non readable property.")
         get() = nonReadable()
         set(value) {

--- a/library/src/main/java/co/zsmb/materialdrawerkt/builders/StickyFooterKt.kt
+++ b/library/src/main/java/co/zsmb/materialdrawerkt/builders/StickyFooterKt.kt
@@ -18,7 +18,8 @@ public class StickyFooterKt(val builder: DrawerBuilder) : Builder {
 
     //region Builder basics
 
-    override fun attachItem(item: IDrawerItem<*, *>) {
+    @Suppress("OverridingDeprecatedMember")
+    public override fun attachItem(item: IDrawerItem<*, *>) {
         builder.addStickyDrawerItems(item)
     }
 

--- a/library/src/main/java/co/zsmb/materialdrawerkt/draweritems/base/AbstractDrawerItemKt.kt
+++ b/library/src/main/java/co/zsmb/materialdrawerkt/draweritems/base/AbstractDrawerItemKt.kt
@@ -13,8 +13,8 @@ public abstract class AbstractDrawerItemKt<out T : AbstractDrawerItem<*, *>>(pro
 
     //region Builder basics
 
-    @Suppress("PARAMETER_NAME_CHANGED_ON_OVERRIDE")
-    override fun attachItem(subItem: IDrawerItem<*, *>) {
+    @Suppress("PARAMETER_NAME_CHANGED_ON_OVERRIDE", "OverridingDeprecatedMember")
+    public override fun attachItem(subItem: IDrawerItem<*, *>) {
         item.withSubItems(subItem)
     }
 

--- a/publish.gradle
+++ b/publish.gradle
@@ -15,8 +15,8 @@ task androidSourcesJar(type: Jar) {
 }
 
 bintray {
-    dryRun = false
-    publish = true
+    dryRun   = false
+    publish  = true
     override = true
 
     Properties properties = new Properties()
@@ -27,20 +27,20 @@ bintray {
     }
 
     user = properties.getProperty('bintrayUser') ?: System.getenv('BINTRAY_USER')
-    key = properties.getProperty('bintrayKey') ?: System.getenv('BINTRAY_API_KEY')
+    key  = properties.getProperty('bintrayKey')  ?: System.getenv('BINTRAY_API_KEY')
 
     publications('release')
 
     pkg {
-        repo = "MaterialDrawerKt"
-        name = "MaterialDrawerKt"
+        repo   = "MaterialDrawerKt"
+        name   = "MaterialDrawerKt"
         vcsUrl = "https://gitlab.com/zsmb/MaterialDrawerKt"
 
         publicDownloadNumbers = true
         licenses = ["Apache-2.0"]
         version {
-            name = PUBLISH_VERSION
-            vcsTag = PUBLISH_VERSION
+            name     = PUBLISH_VERSION
+            vcsTag   = PUBLISH_VERSION
             released = new Date()
         }
     }
@@ -48,9 +48,9 @@ bintray {
     publishing {
         publications {
             release(MavenPublication) {
-                groupId PUBLISH_GROUP_ID
+                groupId    PUBLISH_GROUP_ID
                 artifactId PUBLISH_ARTIFACT_ID
-                version PUBLISH_VERSION
+                version    PUBLISH_VERSION
                 artifact("$buildDir/outputs/aar/${project.getName()}-release.aar")
                 artifact androidSourcesJar
                 artifact androidJavadocsJar
@@ -60,9 +60,9 @@ bintray {
 
                     project.configurations.implementation.allDependencies.each {
                         def dependencyNode = dependenciesNode.appendNode('dependency')
-                        dependencyNode.appendNode('groupId', it.group)
+                        dependencyNode.appendNode('groupId',    it.group)
                         dependencyNode.appendNode('artifactId', it.name)
-                        dependencyNode.appendNode('version', it.version)
+                        dependencyNode.appendNode('version',    it.version)
                     }
                 }
             }


### PR DESCRIPTION
Basically just pushed the refactor button (check 9ce3555), also update the version of some other dependencies (check fff8586 for those changes)
This however (and quite obviously) breaks the public api, as it now requires androidx, due to this major incompatibilty i suggest updating the version to 2.0.0 (as done in 23e1150)